### PR TITLE
docs: clarify monorepo structure + add agentrealm hint to DNA injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,33 @@ make install
 make clean
 ```
 
+## Repository Structure
+
+This is a **monorepo** that publishes two npm packages from a single repository:
+
+| Package | Description |
+|---------|-------------|
+| [`agentic-dna`](https://www.npmjs.com/package/agentic-dna) | The standalone `dna` CLI tool |
+| [`openclaw-dna`](https://www.npmjs.com/package/openclaw-dna) | The OpenClaw plugin (source: `openclaw/index.ts`) |
+
+```
+agentic-dna/
+├── bin/
+│   └── dna                   # CLI entry — routes all `dna` subcommands
+├── lib/                      # Shared CLI implementation modules
+│   └── expand.ts             # {{dna}} directive expansion
+├── openclaw/                 # OpenClaw plugin — published as `openclaw-dna` npm package
+│   ├── index.ts              # Plugin entry: policy injection + directive expansion
+│   ├── dist/                 # Build output (run `cd openclaw && pnpm build`)
+│   ├── skills/               # Bundled AgentSkills
+│   ├── package.json          # openclaw-dna package manifest
+│   └── openclaw.plugin.json  # OpenClaw plugin descriptor
+├── scripts/                  # Utility/build scripts
+└── test/                     # Tests
+```
+
+> **Note for OpenClaw users:** The `openclaw-dna` plugin source lives here at `openclaw/index.ts`. There is no separate `openclaw-dna` repository — both packages are developed and released from this repo.
+
 ## Project Structure
 
 ```

--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -1,3 +1,5 @@
+<!-- Source: `openclaw/` directory in the [agentic-dna](https://github.com/exisz/agentic-dna) monorepo. Plugin entry: `openclaw/index.ts`. Build: `cd openclaw && pnpm build` → `openclaw/dist/`. -->
+
 # openclaw-dna
 
 OpenClaw plugin for [agentic-dna](https://github.com/exisz/agentic-dna) — the agent governance system.

--- a/openclaw/index.ts
+++ b/openclaw/index.ts
@@ -46,6 +46,10 @@ DNA is the governing knowledge system. Before writing anything, know where it be
 Key: if it's universal wisdom → philosophy. If it's an actionable rule → convention. If it's agent-specific → TOOLS.md or dna.yaml.
 </openclaw-dna-guide>`;
 
+const REALM_HINT = `<openclaw-realm-hint>
+For agentless sandbox/scratch workspaces, use \`agentrealm\` (CLI: \`realm\`). Run \`realm skill\` for usage.
+</openclaw-realm-hint>`;
+
 const CRON_POLICY = `<openclaw-cron-policy>
 ## Cron Session Rules (MANDATORY — you are running as a scheduled cron job)
 
@@ -90,6 +94,7 @@ const plugin = {
       (_event, ctx) => {
         const isCron = ctx.trigger === "cron";
         let injectable = DNA_KNOWLEDGE_GUIDE;
+        injectable += "\n\n" + REALM_HINT;
         injectable += "\n\n" + (isCron ? CRON_POLICY : INTERACTIVE_POLICY);
         return { appendSystemContext: injectable };
       },


### PR DESCRIPTION
## Summary

### Task 1: Clarify monorepo structure in docs

- **Top-level `README.md`**: Added `## Repository Structure` section clearly listing all top-level directories and files, explicitly noting that `openclaw/index.ts` is the OpenClaw plugin source published as the `openclaw-dna` npm package. Includes a callout note: *There is no separate `openclaw-dna` repository — both packages are developed and released from this repo.*
- **`openclaw/README.md`**: Added a header comment noting this is sourced from the `openclaw/` directory of the agentic-dna monorepo, the plugin entry, and the build command.

### Task 2: Add agentrealm hint to DNA injection

Added `REALM_HINT` constant to `openclaw/index.ts` — a minimal 3-line block injected in all sessions (both cron and interactive) after the DNA knowledge guide. Tells agents about `agentrealm` / `realm` CLI for agentless sandbox workspaces. This is a **separate peer block** from `DNA_KNOWLEDGE_GUIDE` (realm is not a DNA concept).

Build verified: `cd openclaw && pnpm build` ✅

---

## Task 3: DNA Refactor Candidates (no code changed)

Identified during code review of `openclaw/index.ts`, `bin/dna`, and `lib/`:

1. **`bin/dna` help text indentation inconsistency** — lines for `protocol` and `flow` subcommands use different indentation (extra leading spaces) compared to other entries. Minor but visible in terminal output.

2. **`bin/dna` `init` directory hint bug** — The `init` subcommand prints `"Add philosophy entries to $DATA_DIR/philosophy/"` but the actual directory created is `philosophies/` (plural). Stale copy-paste.

3. **`bin/dna` deprecated aliases (`architecture`, `workflow`) have no removal plan** — They print a warning but will live forever without a `@deprecated-since` comment or scheduled removal. Should be tracked for eventual drop.

4. **Prompt injection constants in `openclaw/index.ts` are inline string literals** — `CRON_POLICY`, `INTERACTIVE_POLICY`, and `DNA_KNOWLEDGE_GUIDE` are large template literals defined at module top-level. As more hints accumulate (now + `REALM_HINT`), this will become unwieldy. Consider moving prompt blocks to `openclaw/prompts/` or a dedicated `prompts.ts` module.

5. **`lib/expand.ts` `clearCache()` call on every bootstrap** — The plugin calls `clearCache()` on every `agent:bootstrap` event so `dna.yaml` edits are picked up. This is correct in dev but may be a silent perf hit in production fleets with frequent bootstrap cycles. Worth adding a TTL-based cache invalidation strategy instead of always-clear.